### PR TITLE
Make JSON artifacts discoverable

### DIFF
--- a/content/neuvector-prime/aws/neuvector-csp-iam-policy.json.lr
+++ b/content/neuvector-prime/aws/neuvector-csp-iam-policy.json.lr
@@ -1,3 +1,1 @@
-_discoverable: no
----
 _attachment_type: application/json

--- a/content/neuvector-prime/aws/neuvector-csp-iam-role.json.lr
+++ b/content/neuvector-prime/aws/neuvector-csp-iam-role.json.lr
@@ -1,3 +1,1 @@
-_discoverable: no
----
 _attachment_type: application/json


### PR DESCRIPTION
The `lektor build` was skipping the NVP json files, as they were set to not discoverable (and that doesn't work with static builds).