### PR TITLE
Fix up helm command for NV in AWS

### DIFF
--- a/content/neuvector-prime/aws/contents.lr
+++ b/content/neuvector-prime/aws/contents.lr
@@ -96,7 +96,10 @@ helm install -n neuvector neuvector --create-namespace \
 oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/suse/{{repository}}/core \
   --version {{chart_version}} \
   --set awsbilling.accountNumber=$AWS_ACCOUNT_ID \
-  --set awsbilling.roleName=$ROLE_NAME
+  --set awsbilling.roleName=$ROLE_NAME \
+  --set containerd.enabled=true \
+  --set aws.enabled=true \
+  --set manager.svc.type=LoadBalancer
 ```
 
 ## Log into the NeuVector dashboard


### PR DESCRIPTION
1st pass automation was missing some arguments; adding them to the documentation as a stopgap to enable customers.