### PR TITLE
add anchors to upgrade section for linking from official docs

### DIFF
--- a/content/rancher-prime/aws/contents.lr
+++ b/content/rancher-prime/aws/contents.lr
@@ -166,6 +166,7 @@ you have chosen previously.
 Please refer to the [Rancher documentation](https://ranchermanager.docs.rancher.com/)
 on how to use Rancher.
 
+<a id="upgrading">&nbsp;</a>
 ## Upgrading a Rancher Prime PAYG Cluster
 
 The marketplace PAYG offer is tied to a billing adapter AND Rancher Prime version. These are updated periodically as new version of the billing adapter or Rancher are released.

--- a/content/rancher-prime/azure/contents.lr
+++ b/content/rancher-prime/azure/contents.lr
@@ -148,6 +148,7 @@ Billing will be available in the Azure Portal billing
 
 Home > Cost Management <subscription\> | Cost analysis
 
+<a id="upgrading">&nbsp;</a>
 ## Upgrading a Rancher Prime PAYG Cluster
 
 The Azure marketplace PAYG offer is periodically updated as a new version of


### PR DESCRIPTION
The Rancher official docs have a PR up ( https://github.com/rancher/rancher-docs/pull/1008 ) for adding PAYG information, I want them to be able to link directly to the upgrade section of the marketplace-docs. 

Added empty anchors at the upgrade header.