### PR TITLE
Include name argument in service account cmd

### DIFF
--- a/content/neuvector-prime/aws/contents.lr
+++ b/content/neuvector-prime/aws/contents.lr
@@ -50,6 +50,7 @@ eksctl create iamserviceaccount \
   --namespace neuvector --cluster $CLUSTER_NAME \
   --role-name $ROLE_NAME --role-only \
   --attach-policy-arn 'arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess' \
+  --name csp \
   --approve
 ```
 


### PR DESCRIPTION
And use explicit set string option in helm install to handle the account id number as a string.